### PR TITLE
Add Algorand TestNet dev utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Algod client configuration
+ALGOD_ADDRESS=https://testnet-api.algonode.cloud
+# Set ALGOD_TOKEN if your provider requires an API token
+ALGOD_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# Fleamarket Algorand TestNet Environment
+
+This repository provides basic utilities for interacting with the Algorand
+TestNet using Python. It is intended as a starting point for developing a
+tokenized auction platform and includes helpers for deploying smart contracts,
+sending test transactions, and creating Algorand Standard Assets (tokens).
+
+## Prerequisites
+
+* Python 3.11+
+* An Algorand TestNet account funded with test Algos. You can obtain them from
+the [Algorand TestNet Faucet](https://bank.testnet.algorand.network).
+* Access to an Algod API endpoint (for example `https://testnet-api.algonode.cloud`).
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a `.env` file in the project root and set the Algod connection
+   parameters. A sample is provided in `.env.example`:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and update the values if necessary.
+
+```
+ALGOD_ADDRESS=https://testnet-api.algonode.cloud
+ALGOD_TOKEN=
+```
+
+If you use a provider that requires an API token (e.g. PureStake), set
+`ALGOD_TOKEN` accordingly. The default configuration connects to the public
+Algonode TestNet endpoint which does not require a token.
+
+## Usage
+
+The `algorand` package exposes helper functions for common tasks:
+
+### Sending a payment transaction
+
+```python
+from algorand import send_payment
+
+PRIVATE_KEY = "your 64-character hex private key"
+RECEIVER = "ALGORECEIVERADDRESS..."
+
+# send 1 Algo (1_000_000 microalgos)
+txid = send_payment(PRIVATE_KEY, RECEIVER, 1_000_000)
+print(f"Payment transaction ID: {txid}")
+```
+
+### Creating an Algorand Standard Asset
+
+```python
+from algorand import create_asset
+
+PRIVATE_KEY = "..."
+
+txid = create_asset(PRIVATE_KEY, "AuctionToken", "AUCT", total=1000)
+print(f"Asset creation TXID: {txid}")
+```
+
+### Deploying a simple smart contract
+
+```python
+from algorand import deploy_app, compile_teal
+
+approval_teal = "int 1"  # always approve
+clear_teal = "int 1"
+
+PRIVATE_KEY = "..."
+
+txid = deploy_app(PRIVATE_KEY, approval_teal, clear_teal)
+print(f"Application creation TXID: {txid}")
+```
+
+### Deploying the auction contract
+
+The `auction` module provides a ready-to-use PyTeal contract that manages a
+simple ASA auction. The asset is transferred to the application's address and
+participants bid by sending a payment alongside the application call. The
+highest bidder can claim the asset after the auction ends.
+
+```python
+from algorand import deploy_auction_app
+
+PRIVATE_KEY = "seller private key"
+ASA_ID = 123456  # ID of the asset to auction
+START = 1700000000  # auction start timestamp
+END = 1700003600    # auction end timestamp
+RESERVE = 1_000_000  # minimum bid in microalgos
+
+txid = deploy_auction_app(PRIVATE_KEY, ASA_ID, START, END, RESERVE)
+print(f"Auction app creation TXID: {txid}")
+```
+
+## Testing
+
+You can run a simple syntax check on the modules:
+
+```bash
+python -m py_compile algorand/*.py
+```
+
+These utilities interact with the Algorand TestNet. Ensure the environment
+variables are set correctly before running the examples.

--- a/algorand/__init__.py
+++ b/algorand/__init__.py
@@ -1,0 +1,22 @@
+"""Utilities for working with the Algorand TestNet."""
+
+from .client import get_algod_client
+from .transactions import send_payment
+from .asset import create_asset
+from .contracts import deploy_app, compile_teal
+from .auction import (
+    approval_program as auction_approval_program,
+    clear_program as auction_clear_program,
+    deploy_auction_app,
+)
+
+__all__ = [
+    "get_algod_client",
+    "send_payment",
+    "create_asset",
+    "deploy_app",
+    "compile_teal",
+    "deploy_auction_app",
+    "auction_approval_program",
+    "auction_clear_program",
+]

--- a/algorand/asset.py
+++ b/algorand/asset.py
@@ -1,0 +1,28 @@
+from algosdk import account
+from algosdk.future import transaction
+
+from .client import get_algod_client
+
+
+def create_asset(private_key: str, asset_name: str, unit_name: str, total: int, decimals: int = 0, url: str = "") -> str:
+    """Create an Algorand Standard Asset and return the transaction ID."""
+    client = get_algod_client()
+    sender = account.address_from_private_key(private_key)
+    params = client.suggested_params()
+    txn = transaction.AssetCreateTxn(
+        sender=sender,
+        sp=params,
+        total=total,
+        decimals=decimals,
+        default_frozen=False,
+        unit_name=unit_name,
+        asset_name=asset_name,
+        manager=sender,
+        reserve=sender,
+        freeze=sender,
+        clawback=sender,
+        url=url,
+    )
+    signed = txn.sign(private_key)
+    txid = client.send_transaction(signed)
+    return txid

--- a/algorand/auction.py
+++ b/algorand/auction.py
@@ -1,0 +1,127 @@
+from algosdk.future import transaction
+from pyteal import *
+
+from .contracts import deploy_app
+
+
+def approval_program() -> str:
+    """Return the PyTeal approval program for a basic auction."""
+    seller = Bytes("seller")
+    asset = Bytes("asset_id")
+    start = Bytes("start")
+    end = Bytes("end")
+    reserve = Bytes("reserve")
+    highest_bid = Bytes("highest_bid")
+    highest_bidder = Bytes("highest_bidder")
+    closed = Bytes("closed")
+
+    on_create = Seq(
+        Assert(Txn.application_args.length() == Int(4)),
+        App.globalPut(seller, Txn.sender()),
+        App.globalPut(asset, Btoi(Txn.application_args[0])),
+        App.globalPut(start, Btoi(Txn.application_args[1])),
+        App.globalPut(end, Btoi(Txn.application_args[2])),
+        App.globalPut(reserve, Btoi(Txn.application_args[3])),
+        App.globalPut(highest_bid, Int(0)),
+        App.globalPut(highest_bidder, Global.zero_address()),
+        App.globalPut(closed, Int(0)),
+        Approve(),
+    )
+
+    bid_payment = Gtxn[0]
+
+    refund_prev = Seq(
+        InnerTxnBuilder.Begin(),
+        InnerTxnBuilder.SetFields(
+            {
+                TxnField.type_enum: TxnType.Payment,
+                TxnField.receiver: App.globalGet(highest_bidder),
+                TxnField.amount: App.globalGet(highest_bid),
+                TxnField.fee: Int(0),
+            }
+        ),
+        InnerTxnBuilder.Submit(),
+    )
+
+    on_bid = Seq(
+        Assert(App.globalGet(closed) == Int(0)),
+        Assert(Global.latest_timestamp() >= App.globalGet(start)),
+        Assert(Global.latest_timestamp() < App.globalGet(end)),
+        Assert(bid_payment.type_enum() == TxnType.Payment),
+        Assert(bid_payment.sender() == Txn.sender()),
+        Assert(bid_payment.receiver() == Global.current_application_address()),
+        Assert(bid_payment.amount() > App.globalGet(highest_bid)),
+        Assert(bid_payment.amount() >= App.globalGet(reserve)),
+        If(App.globalGet(highest_bid) > Int(0)).Then(refund_prev),
+        App.globalPut(highest_bid, bid_payment.amount()),
+        App.globalPut(highest_bidder, Txn.sender()),
+        Approve(),
+    )
+
+    on_claim = Seq(
+        Assert(App.globalGet(closed) == Int(0)),
+        Assert(Global.latest_timestamp() >= App.globalGet(end)),
+        Assert(Txn.sender() == App.globalGet(highest_bidder)),
+        InnerTxnBuilder.Begin(),
+        InnerTxnBuilder.SetFields(
+            {
+                TxnField.type_enum: TxnType.AssetTransfer,
+                TxnField.xfer_asset: App.globalGet(asset),
+                TxnField.asset_receiver: App.globalGet(highest_bidder),
+                TxnField.asset_amount: Int(1),
+                TxnField.fee: Int(0),
+            }
+        ),
+        InnerTxnBuilder.Submit(),
+        InnerTxnBuilder.Begin(),
+        InnerTxnBuilder.SetFields(
+            {
+                TxnField.type_enum: TxnType.Payment,
+                TxnField.receiver: App.globalGet(seller),
+                TxnField.amount: App.globalGet(highest_bid),
+                TxnField.fee: Int(0),
+            }
+        ),
+        InnerTxnBuilder.Submit(),
+        App.globalPut(closed, Int(1)),
+        Approve(),
+    )
+
+    program = Cond(
+        [Txn.application_id() == Int(0), on_create],
+        [Txn.on_completion() == OnComplete.NoOp, Cond([
+            Txn.application_args[0] == Bytes("bid"), on_bid
+        ], [
+            Txn.application_args[0] == Bytes("claim"), on_claim
+        ])],
+        [Txn.on_completion() == OnComplete.DeleteApplication, Return(Txn.sender() == App.globalGet(seller))],
+        [Txn.on_completion() == OnComplete.UpdateApplication, Return(Txn.sender() == App.globalGet(seller))],
+        [Txn.on_completion() == OnComplete.CloseOut, Approve()],
+        [Txn.on_completion() == OnComplete.OptIn, Approve()],
+    )
+
+    return compileTeal(program, mode=Mode.Application, version=7)
+
+
+def clear_program() -> str:
+    """Clear state program that always approves."""
+    return compileTeal(Approve(), mode=Mode.Application, version=7)
+
+
+def deploy_auction_app(private_key: str, asset_id: int, start: int, end: int, reserve: int) -> str:
+    """Deploy the auction contract to the blockchain and return the transaction ID."""
+    app_args = [
+        asset_id.to_bytes(8, "big"),
+        start.to_bytes(8, "big"),
+        end.to_bytes(8, "big"),
+        reserve.to_bytes(8, "big"),
+    ]
+    global_schema = transaction.StateSchema(7, 2)
+    return deploy_app(
+        private_key,
+        approval_program(),
+        clear_program(),
+        global_schema=global_schema,
+        local_schema=transaction.StateSchema(0, 0),
+        app_args=app_args,
+    )

--- a/algorand/client.py
+++ b/algorand/client.py
@@ -1,0 +1,10 @@
+import os
+from algosdk.v2client import algod
+
+
+def get_algod_client() -> algod.AlgodClient:
+    """Create an Algod client using environment variables."""
+    address = os.getenv("ALGOD_ADDRESS", "https://testnet-api.algonode.cloud")
+    token = os.getenv("ALGOD_TOKEN", "")
+    headers = {"X-API-Key": token} if token else None
+    return algod.AlgodClient(token, address, headers)

--- a/algorand/contracts.py
+++ b/algorand/contracts.py
@@ -1,0 +1,38 @@
+import base64
+from algosdk import account, transaction
+
+from .client import get_algod_client
+
+
+def compile_teal(teal_source: str) -> bytes:
+    """Compile TEAL source to bytecode using the Algod client."""
+    client = get_algod_client()
+    compile_response = client.compile(teal_source)
+    return base64.b64decode(compile_response["result"])
+
+
+def deploy_app(private_key: str, approval_program: str, clear_program: str,
+               global_schema: transaction.StateSchema | None = None,
+               local_schema: transaction.StateSchema | None = None,
+               app_args: list[bytes] | None = None) -> str:
+    """Deploy a PyTeal application and return the transaction ID."""
+    client = get_algod_client()
+    sender = account.address_from_private_key(private_key)
+    params = client.suggested_params()
+    if global_schema is None:
+        global_schema = transaction.StateSchema(0, 0)
+    if local_schema is None:
+        local_schema = transaction.StateSchema(0, 0)
+    txn = transaction.ApplicationCreateTxn(
+        sender=sender,
+        sp=params,
+        on_complete=transaction.OnComplete.NoOpOC.real,
+        approval_program=compile_teal(approval_program),
+        clear_program=compile_teal(clear_program),
+        global_schema=global_schema,
+        local_schema=local_schema,
+        app_args=app_args,
+    )
+    signed = txn.sign(private_key)
+    txid = client.send_transaction(signed)
+    return txid

--- a/algorand/transactions.py
+++ b/algorand/transactions.py
@@ -1,0 +1,14 @@
+from algosdk import account, transaction
+
+from .client import get_algod_client
+
+
+def send_payment(private_key: str, receiver: str, amount: int) -> str:
+    """Send Algos to ``receiver`` and return the transaction ID."""
+    client = get_algod_client()
+    sender = account.address_from_private_key(private_key)
+    params = client.suggested_params()
+    txn = transaction.PaymentTxn(sender, params, receiver, amount)
+    signed = txn.sign(private_key)
+    txid = client.send_transaction(signed)
+    return txid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 py-algorand-sdk==2.0.0
 python-dotenv==1.0.1
+pyteal==0.27.0


### PR DESCRIPTION
## Summary
- add utilities for connecting to the Algorand TestNet
- include helper functions for payments, asset creation, and contract deployment
- add PyTeal auction contract with deploy helper
- document setup and usage
- provide `.env.example` and ignore caches

## Testing
- `pip install -r requirements.txt`
- `pip install pyteal`
- `python -m py_compile algorand/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6878f5299998832c9abc762521828727