### PR TITLE
Replace imghdr with filetype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ qrcode==7.4.2
 
 streamlit-javascript
 pywalletconnect
+filetype==1.2.0


### PR DESCRIPTION
## Summary
- replace deprecated `imghdr` checks with `filetype` and PIL verification
- add `filetype` dependency

## Testing
- `python -m py_compile streamlit_app.py algorand/*.py`
- `python -m py_compile streamlit_app_diagnostic.py`


------
https://chatgpt.com/codex/tasks/task_e_6882725532cc832cb02e8060a5e6eaff