### PR TITLE
Add Your Listings tab with inline listing form

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ An alternative multi-tab demo is available in `streamlit_multi_app.py`:
 streamlit run streamlit_multi_app.py
 ```
 
-This version organizes the interface into Marketplace, Connect Wallet, List Item
-and Bid tabs using `st.sidebar.radio`.
+This version organizes the interface into Marketplace, Connect Wallet, Your Listings
+and Bid tabs using `st.tabs`.
 
 ## Supabase Integration
 


### PR DESCRIPTION
## Summary
- add session state control for inline listing form
- introduce `Your Listings` tab to view and create user listings
- remove standalone Create Listing tab and document new tab structure

## Testing
- `python -m py_compile streamlit_multi_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688e4ab26efc832ca88b7c13ea7120d6